### PR TITLE
Added the controls and playsinline attribute to video tags.

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -8,7 +8,7 @@ function Component1() {
     <div className="max-w-full mx-auto flex justify-between gap-5 py-8 2xl:px-48 lg:py-20 px-8 bg-gray-100 sectionA place-items-center">
       <div className="w-[100%] lg:w-[80%] hidden md:block">
         <figure>
-          <video className="diagram screenshot" autoPlay loop muted>
+          <video className="diagram screenshot" autoPlay loop muted controls webkit-playsinline>
             <source src="/img/case-study/3.1-demo.mp4" type="video/mp4" />
           </video>
         </figure>
@@ -23,6 +23,8 @@ function Component1() {
             autoPlay
             loop
             muted
+            controls
+            webkit-playsinline
           >
             <source src="/img/case-study/3.1-demo.mp4" type="video/mp4" />
           </video>

--- a/src/pages/case-study.md
+++ b/src/pages/case-study.md
@@ -163,7 +163,7 @@ The best way to understand what Willow does is by seeing it in action. In the vi
 Initially, the PostgreSQL `store` table and the Redis cache are empty. Once a row is inserted into `store`, Willow replicates the row in the cache. After refreshing RedisInsight, we can see that the row inserted into our PostgreSQL table has been replicated in our Redis cache.
 
 <figure >
-  <video className="diagram screenshot" autoPlay loop muted>
+  <video className="diagram screenshot" autoPlay loop muted controls webkit-playsinline>
     <source src="/img/case-study/3.1-demo.mp4" type="video/mp4" />
   </video>
 </figure>


### PR DESCRIPTION
We were seeing issues in Safari on mobile where the RedisInsights video would pop up on the Case Study and Landing Page. These attributes were added to mitigate this issue. See [this](https://stackoverflow.com/questions/76747828/html-video-popping-up-in-ios-devices) Stackoverflow post for additional information and the suggestion.