### PR TITLE
fix(demo): :bug: Fix demo on home page for smaller screens to use gif instead of mp4.

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -16,16 +16,7 @@ function Component1() {
           Sync caches in near real-time using change data capture
         </h1>
         <figure>
-          <video
-            className="diagram screenshot max-w-[450px] md:hidden w-[90%]"
-            autoPlay
-            loop
-            muted
-            controls
-            webkit-playsinline
-          >
-            <source src="/img/case-study/3.1-demo.mp4" type="video/mp4" />
-          </video>
+          <img src="/img/case-study/3.1-demo.gif" className="diagram screenshot" alt="A demonstration of Willow. On the left side of the screen is a PostgreSQL terminal. On the right side of the screen is a Redis cache shown in RedisInsight. An INSERT command is performed in the PostgreSQL terminal, and the inserted data automatically appears in the Redis cache."/>
         </figure>
         <p className="text-gray-600 dark:text-slate-100 uppercase text-large tracking-wide font-semibold mt-6 mb-2">
           Technologies


### PR DESCRIPTION
I missed changing the home page's smaller screen demo to use the gif instead of mp4 in the last PR. Fixing that in this one.