### PR TITLE
Add image extension to Docusaurus config

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -62,7 +62,7 @@ const config: Config = {
 
   themeConfig: {
     // Replace with your project's social card
-    image: "img/willow_transparent",
+    image: "img/willow_transparent.png",
     navbar: {
       title: "Willow",
       logo: {


### PR DESCRIPTION
Right now, when we post willow-cdc.github.io on LinkedIn as a link in a post, the Willow logo doesn't show up.

![image](https://github.com/willow-cdc/willow-cdc.github.io/assets/93567829/34f90bab-72f9-48cf-9b71-771d02939f87)

I suspect this is because we didn't put the extension on the image path in the Docusaurus config. If you go to [https://willow-cdc.github.io/img/willow_transparent](https://willow-cdc.github.io/img/willow_transparent), then you get a 404 page. But if you go to [https://willow-cdc.github.io/img/willow_transparent.png](https://willow-cdc.github.io/img/willow_transparent.png), you successfully retrieve the image. 

I'm hoping this helps LinkedIn (and maybe other search engines) find the Willow logo.